### PR TITLE
[MS-432] Fix recursion detection of mutual parents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## Unreleased
 
+### Fixed
+
+- Recursion detection of a mutual parent
+
 ## [9.3.0](https://github.com/dbmdz/metadata-service/releases/tag/9.3.0) - 2024-07-09
 
 ### Added


### PR DESCRIPTION
Case: A has parents B and C, and B's parent is also C This is not a recursion but was mistakenly detected as one.